### PR TITLE
Add Dogear Manager plugin for KOReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# Dogear Manager — KOReader Plugin
+
+A native, on-device interface for KOReader that lets you swap and resize your digital bookmark ("dogear") without ever needing a computer.
+
+## Target Environment
+
+- **Hardware**: Jailbroken Amazon Kindle 10th Generation
+- **Software**: KOReader v2025.10
+
+## Installation
+
+1. Connect your Kindle to a computer via USB.
+2. Copy the `dogearmanager.koplugin` folder into your KOReader plugins directory:
+   ```
+   /mnt/us/koreader/plugins/dogearmanager.koplugin/
+   ```
+3. (Optional) Create the custom designs folder and add your bookmark images:
+   ```
+   /mnt/us/koreader/icons/dogears/
+   ```
+   Supported formats: `.png`, `.svg`, `.bmp`, `.jpg`, `.jpeg`, `.alpha`
+4. Restart KOReader.
+
+## Usage
+
+1. Open the top menu in KOReader.
+2. Go to **Tools** → **Dogear Manager**.
+3. Choose an option:
+   - **Change Bookmark Design** — pick from any custom images you placed in the `icons/dogears/` folder.
+   - **Adjust Bookmark Size** — enter a numeric multiplier (e.g., `2` for 2x larger, `0.5` for half size).
+4. When prompted, tap **Restart** to apply changes.
+
+## How It Works
+
+The plugin saves two settings to KOReader's global configuration:
+
+| Setting | Description |
+|---|---|
+| `dogear_custom_icon` | Full path to the selected custom dogear image |
+| `dogear_scale_factor` | Numeric multiplier for the dogear size (default: 1) |
+
+These settings are read by KOReader's `ReaderDogear` widget on startup. A KOReader restart is required after changes so the widget reinitializes with the new values.
+
+## File Structure
+
+```
+dogearmanager.koplugin/
+├── _meta.lua    # Plugin metadata (name, description)
+└── main.lua     # Plugin logic (menus, scanning, settings)
+```
+
+## Adding Custom Designs
+
+Place your custom bookmark image files in:
+```
+<koreader_data_dir>/icons/dogears/
+```
+
+On a Kindle, this is typically:
+```
+/mnt/us/koreader/icons/dogears/
+```
+
+The plugin scans this folder and displays all valid images in a selectable list.

--- a/dogearmanager.koplugin/_meta.lua
+++ b/dogearmanager.koplugin/_meta.lua
@@ -1,0 +1,6 @@
+local _ = require("gettext")
+return {
+    name = "dogearmanager",
+    fullname = _("Dogear Manager"),
+    description = _([[Swap and resize your digital bookmark (dogear) directly from KOReader's Tools menu.]]),
+}

--- a/dogearmanager.koplugin/main.lua
+++ b/dogearmanager.koplugin/main.lua
@@ -1,0 +1,235 @@
+--[[--
+Dogear Manager plugin for KOReader.
+
+Allows users to swap and resize their digital bookmark (dogear) icon
+directly from the Tools menu, without needing a computer.
+
+Custom dogear designs should be placed as image files in:
+    <koreader_data_dir>/icons/dogears/
+
+@module koplugin.DogearManager
+--]]--
+
+local ConfirmBox = require("ui/widget/confirmbox")
+local DataStorage = require("datastorage")
+local Device = require("device")
+local InfoMessage = require("ui/widget/infomessage")
+local InputDialog = require("ui/widget/inputdialog")
+local UIManager = require("ui/uimanager")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local lfs = require("libs/libkoreader-lfs")
+local _ = require("gettext")
+
+local DogearManager = WidgetContainer:extend{
+    name = "dogearmanager",
+    is_doc_only = false,
+}
+
+-- Supported image extensions for dogear designs.
+local SUPPORTED_EXTENSIONS = {
+    [".png"] = true,
+    [".svg"] = true,
+    [".alpha"] = true,
+    [".bmp"] = true,
+    [".jpg"] = true,
+    [".jpeg"] = true,
+}
+
+--- Returns the path to the dogear icons folder.
+function DogearManager:getIconsDir()
+    return DataStorage:getDataDir() .. "/icons/dogears"
+end
+
+--- Scans the icons/dogears folder and returns a list of valid image filenames.
+function DogearManager:scanDesigns()
+    local icons_dir = self:getIconsDir()
+    local designs = {}
+
+    local ok, iter, dir_obj = pcall(lfs.dir, icons_dir)
+    if not ok then
+        return designs
+    end
+
+    for entry in iter, dir_obj do
+        if entry ~= "." and entry ~= ".." then
+            local ext = entry:match("(%.[^%.]+)$")
+            if ext and SUPPORTED_EXTENSIONS[ext:lower()] then
+                table.insert(designs, entry)
+            end
+        end
+    end
+
+    table.sort(designs)
+    return designs
+end
+
+--- Prompts the user to restart KOReader so changes take effect.
+function DogearManager:promptRestart()
+    UIManager:show(ConfirmBox:new{
+        text = _("Do you want to restart now to see the changes?"),
+        ok_text = _("Restart"),
+        cancel_text = _("Cancel"),
+        ok_callback = function()
+            if Device:canRestart() then
+                UIManager:restartKOReader()
+            else
+                UIManager:show(InfoMessage:new{
+                    text = _("Automatic restart is not supported on this device. Please restart KOReader manually."),
+                })
+            end
+        end,
+    })
+end
+
+--- Applies the selected design by saving it to settings.
+function DogearManager:applyDesign(filename)
+    local full_path = self:getIconsDir() .. "/" .. filename
+    G_reader_settings:saveSetting("dogear_custom_icon", full_path)
+    G_reader_settings:saveSetting("dogear_custom_icon_name", filename)
+
+    UIManager:show(InfoMessage:new{
+        text = _("Bookmark design set to: ") .. filename,
+        timeout = 2,
+    })
+
+    UIManager:scheduleIn(2.5, function()
+        self:promptRestart()
+    end)
+end
+
+--- Shows the design selection submenu.
+function DogearManager:showDesignMenu()
+    local designs = self:scanDesigns()
+
+    if #designs == 0 then
+        local icons_dir = self:getIconsDir()
+        UIManager:show(InfoMessage:new{
+            text = _("No custom bookmark designs found.\n\nPlace image files (.png, .svg, .bmp, .jpg) in:\n") .. icons_dir,
+        })
+        return
+    end
+
+    -- Build menu items from scanned designs.
+    local menu_items = {}
+    for _, filename in ipairs(designs) do
+        table.insert(menu_items, {
+            text = filename,
+            callback = function()
+                self:applyDesign(filename)
+            end,
+        })
+    end
+
+    -- Add an option to reset to the default dogear.
+    table.insert(menu_items, {
+        text = _("-- Reset to Default --"),
+        callback = function()
+            G_reader_settings:delSetting("dogear_custom_icon")
+            G_reader_settings:delSetting("dogear_custom_icon_name")
+            UIManager:show(InfoMessage:new{
+                text = _("Bookmark design reset to default."),
+                timeout = 2,
+            })
+            UIManager:scheduleIn(2.5, function()
+                self:promptRestart()
+            end)
+        end,
+    })
+
+    local Menu = require("ui/widget/menu")
+    local Screen = Device.screen
+
+    local design_menu = Menu:new{
+        title = _("Change Bookmark Design"),
+        item_table = menu_items,
+        width = Screen:getWidth(),
+        height = Screen:getHeight(),
+        close_callback = function()
+            UIManager:close(design_menu)
+        end,
+    }
+
+    UIManager:show(design_menu)
+end
+
+--- Shows the size adjustment dialog with a numeric keypad.
+function DogearManager:showSizeDialog()
+    local current_scale = G_reader_settings:readSetting("dogear_scale_factor") or 1
+    local size_dialog
+
+    size_dialog = InputDialog:new{
+        title = _("Adjust Bookmark Size"),
+        description = _("Enter a size multiplier (e.g., 1 = default, 2 = twice as large, 0.5 = half size):"),
+        input = tostring(current_scale),
+        input_type = "number",
+        input_hint = "1",
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    id = "close",
+                    callback = function()
+                        UIManager:close(size_dialog)
+                    end,
+                },
+                {
+                    text = _("Apply"),
+                    is_enter_default = true,
+                    callback = function()
+                        local value = size_dialog:getInputValue()
+                        if value and type(value) == "number" and value > 0 then
+                            G_reader_settings:saveSetting("dogear_scale_factor", value)
+                            UIManager:close(size_dialog)
+
+                            UIManager:show(InfoMessage:new{
+                                text = _("Bookmark size set to ") .. tostring(value) .. "x",
+                                timeout = 2,
+                            })
+
+                            UIManager:scheduleIn(2.5, function()
+                                self:promptRestart()
+                            end)
+                        else
+                            UIManager:show(InfoMessage:new{
+                                text = _("Please enter a valid positive number."),
+                                timeout = 2,
+                            })
+                        end
+                    end,
+                },
+            },
+        },
+    }
+
+    UIManager:show(size_dialog)
+    size_dialog:onShowKeyboard()
+end
+
+function DogearManager:init()
+    self.ui.menu:registerToMainMenu(self)
+end
+
+function DogearManager:addToMainMenu(menu_items)
+    menu_items.dogear_manager = {
+        text = _("Dogear Manager"),
+        sorting_hint = "tools",
+        sub_item_table = {
+            {
+                text = _("Change Bookmark Design"),
+                keep_menu_open = false,
+                callback = function()
+                    self:showDesignMenu()
+                end,
+            },
+            {
+                text = _("Adjust Bookmark Size"),
+                keep_menu_open = false,
+                callback = function()
+                    self:showSizeDialog()
+                end,
+            },
+        },
+    }
+end
+
+return DogearManager


### PR DESCRIPTION
Implements a KOReader plugin that lets users swap and resize their
bookmark (dogear) icon directly from the Tools menu on a Kindle,
without needing a computer.

Features:
- Scans icons/dogears/ folder for custom bookmark designs
- Presents designs in a scrollable list for one-tap selection
- Numeric input dialog for size multiplier adjustment
- Restart prompt to apply changes immediately
- Empty state handling when no custom designs are found
- Reset to default option

https://claude.ai/code/session_01T3h6ZHKnGopnc9yvzYv2VV