### PR TITLE
Fix icon resize scaling and replace input dialog with live slider

### DIFF
--- a/dogearmanager.koplugin/main.lua
+++ b/dogearmanager.koplugin/main.lua
@@ -11,12 +11,24 @@ Custom dogear designs can be placed in either:
 @module koplugin.DogearManager
 --]]--
 
+local Blitbuffer = require("ffi/blitbuffer")
+local Button = require("ui/widget/button")
+local CenterContainer = require("ui/widget/container/centercontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
 local DataStorage = require("datastorage")
 local Device = require("device")
+local Font = require("ui/font")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local Geom = require("ui/geometry")
+local HorizontalGroup = require("ui/widget/horizontalgroup")
+local HorizontalSpan = require("ui/widget/horizontalspan")
+local ImageWidget = require("ui/widget/imagewidget")
 local InfoMessage = require("ui/widget/infomessage")
-local InputDialog = require("ui/widget/inputdialog")
+local Size = require("ui/size")
+local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local VerticalSpan = require("ui/widget/verticalspan")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local lfs = require("libs/libkoreader-lfs")
 local _ = require("gettext")
@@ -164,71 +176,193 @@ function DogearManager:showDesignMenu()
     UIManager:show(design_menu)
 end
 
---- Shows the size adjustment dialog with a numeric keypad.
-function DogearManager:showSizeDialog()
-    local current_scale = G_reader_settings:readSetting("dogear_scale_factor") or 1
-    local size_dialog
+--- Shows the size adjustment dialog with a slider and live icon preview.
+-- Builds (or rebuilds) the dialog at the given scale value.
+-- @param scale number  current scale factor (default: read from settings)
+function DogearManager:showSizeSlider(scale)
+    local Screen = Device.screen
 
-    size_dialog = InputDialog:new{
-        title = _("Adjust Bookmark Size"),
-        description = _("Enter a size multiplier (e.g., 1 = default, 2 = twice as large, 0.5 = half size):"),
-        input = tostring(current_scale),
-        input_type = "number",
-        input_hint = "1",
-        buttons = {
-            {
-                {
-                    text = _("Cancel"),
-                    id = "close",
-                    callback = function()
-                        UIManager:close(size_dialog)
-                    end,
-                },
-                {
-                    text = _("Reset"),
-                    callback = function()
-                        G_reader_settings:delSetting("dogear_scale_factor")
-                        UIManager:close(size_dialog)
-                        UIManager:show(InfoMessage:new{
-                            text = _("Bookmark size reset to default."),
-                            timeout = 2,
-                        })
-                        UIManager:scheduleIn(2.5, function()
-                            self:promptRestart()
-                        end)
-                    end,
-                },
-                {
-                    text = _("Apply"),
-                    is_enter_default = true,
-                    callback = function()
-                        local value = size_dialog:getInputValue()
-                        if value and type(value) == "number" and value > 0 then
-                            G_reader_settings:saveSetting("dogear_scale_factor", value)
-                            UIManager:close(size_dialog)
+    -- Read saved scale if not provided; clamp and round to nearest 0.1.
+    if not scale then
+        scale = G_reader_settings:readSetting("dogear_scale_factor") or 1
+    end
+    scale = math.floor(scale * 10 + 0.5) / 10
+    scale = math.max(0.5, math.min(4.0, scale))
 
-                            UIManager:show(InfoMessage:new{
-                                text = _("Bookmark size set to ") .. tostring(value) .. "x",
-                                timeout = 2,
-                            })
+    -- Base preview size (approximates real dogear at scale 1.0).
+    local base_px    = Screen:scaleBySize(40)
+    local preview_px = math.max(12, math.floor(base_px * scale))
 
-                            UIManager:scheduleIn(2.5, function()
-                                self:promptRestart()
-                            end)
-                        else
-                            UIManager:show(InfoMessage:new{
-                                text = _("Please enter a valid positive number."),
-                                timeout = 2,
-                            })
-                        end
-                    end,
+    local custom_icon = G_reader_settings:readSetting("dogear_custom_icon")
+
+    -- Build the icon preview widget.
+    local preview_widget
+    if custom_icon and lfs.attributes(custom_icon, "mode") == "file" then
+        preview_widget = ImageWidget:new{
+            file   = custom_icon,
+            width  = preview_px,
+            height = preview_px,
+            alpha  = true,
+        }
+    else
+        -- Solid black square as a stand-in for the dogear corner.
+        preview_widget = FrameContainer:new{
+            width      = preview_px,
+            height     = preview_px,
+            background = Blitbuffer.COLOR_BLACK,
+            bordersize = 0,
+            padding    = 0,
+        }
+    end
+
+    -- top_widget is the root widget passed to UIManager:show / close.
+    -- Declare it here so button closures can reference it.
+    local top_widget
+
+    -- Close the dialog and rebuild at a new scale (live-update pattern).
+    local function rebuild(new_scale)
+        UIManager:close(top_widget)
+        self:showSizeSlider(new_scale)
+    end
+
+    -- ── layout helpers ─────────────────────────────────────────────────
+    local dialog_w  = math.floor(Screen:getWidth() * 0.82)
+    local pad       = Size.padding.large
+    local inner_w   = dialog_w - pad * 2
+    -- Fixed preview area height keeps the dialog from jumping in size.
+    local preview_h = base_px * 4 + pad * 2
+    local hspan     = Size.span.horizontal_default
+    local vspan_lg  = Size.span.vertical_large
+    local vspan_def = Size.span.vertical_default
+
+    -- ── controls row: −0.5  −  [value]  +  +0.5 ───────────────────────
+    local step_btn_w  = math.floor(inner_w / 6)
+    local value_box_w = math.floor(inner_w / 4)
+
+    local controls_row = HorizontalGroup:new{
+        align = "center",
+        Button:new{
+            text     = "-0.5",
+            width    = step_btn_w,
+            callback = function()
+                rebuild(math.max(0.5, math.floor((scale - 0.5) * 10 + 0.5) / 10))
+            end,
+        },
+        HorizontalSpan:new{ width = hspan },
+        Button:new{
+            text     = "-",
+            width    = step_btn_w,
+            callback = function()
+                rebuild(math.max(0.5, math.floor((scale - 0.1) * 10 + 0.5) / 10))
+            end,
+        },
+        HorizontalSpan:new{ width = hspan },
+        CenterContainer:new{
+            dimen = Geom:new{ w = value_box_w, h = Screen:scaleBySize(32) },
+            TextWidget:new{
+                text = string.format("%.1fx", scale),
+                face = Font:getFace("cfont", 22),
+                bold = true,
+            },
+        },
+        HorizontalSpan:new{ width = hspan },
+        Button:new{
+            text     = "+",
+            width    = step_btn_w,
+            callback = function()
+                rebuild(math.min(4.0, math.floor((scale + 0.1) * 10 + 0.5) / 10))
+            end,
+        },
+        HorizontalSpan:new{ width = hspan },
+        Button:new{
+            text     = "+0.5",
+            width    = step_btn_w,
+            callback = function()
+                rebuild(math.min(4.0, math.floor((scale + 0.5) * 10 + 0.5) / 10))
+            end,
+        },
+    }
+
+    -- ── action row: Cancel  Reset  Apply ───────────────────────────────
+    local actions_row = HorizontalGroup:new{
+        align = "center",
+        Button:new{
+            text     = _("Cancel"),
+            callback = function()
+                UIManager:close(top_widget)
+            end,
+        },
+        HorizontalSpan:new{ width = hspan },
+        Button:new{
+            text     = _("Reset"),
+            callback = function()
+                G_reader_settings:delSetting("dogear_scale_factor")
+                UIManager:close(top_widget)
+                UIManager:show(InfoMessage:new{
+                    text    = _("Bookmark size reset to default."),
+                    timeout = 2,
+                })
+                UIManager:scheduleIn(2.5, function()
+                    self:promptRestart()
+                end)
+            end,
+        },
+        HorizontalSpan:new{ width = hspan },
+        Button:new{
+            text     = _("Apply"),
+            callback = function()
+                G_reader_settings:saveSetting("dogear_scale_factor", scale)
+                UIManager:close(top_widget)
+                UIManager:show(InfoMessage:new{
+                    text    = _("Bookmark size set to ") .. string.format("%.1f", scale) .. "x",
+                    timeout = 2,
+                })
+                UIManager:scheduleIn(2.5, function()
+                    self:promptRestart()
+                end)
+            end,
+        },
+    }
+
+    -- ── assemble dialog ────────────────────────────────────────────────
+    top_widget = CenterContainer:new{
+        dimen = Screen:getSize(),
+        FrameContainer:new{
+            background = Blitbuffer.COLOR_WHITE,
+            bordersize = Size.border.window,
+            radius     = Size.radius.window,
+            padding    = pad,
+            VerticalGroup:new{
+                align = "center",
+                -- Title
+                TextWidget:new{
+                    text = _("Adjust Bookmark Size"),
+                    face = Font:getFace("cfont", 22),
+                    bold = true,
                 },
+                VerticalSpan:new{ width = vspan_lg },
+                -- Preview label
+                TextWidget:new{
+                    text = _("Preview (tap \194\177 to resize):"),
+                    face = Font:getFace("cfont", 16),
+                },
+                VerticalSpan:new{ width = vspan_def },
+                -- Preview area (fixed height so dialog doesn't jump)
+                CenterContainer:new{
+                    dimen = Geom:new{ w = inner_w, h = preview_h },
+                    preview_widget,
+                },
+                VerticalSpan:new{ width = vspan_lg },
+                -- Scale controls
+                controls_row,
+                VerticalSpan:new{ width = vspan_lg },
+                -- Action buttons
+                actions_row,
             },
         },
     }
 
-    UIManager:show(size_dialog)
-    size_dialog:onShowKeyboard()
+    UIManager:show(top_widget)
 end
 
 --- Patches KOReader's ReaderDogear widget to apply saved scale and icon settings.
@@ -236,7 +370,7 @@ end
 -- dogear_scale_factor or dogear_custom_icon on its own, so we monkey-patch its
 -- init() and setupDogear() methods here to inject our values.
 function DogearManager:patchReaderDogear()
-    local scale_factor = G_reader_settings:readSetting("dogear_scale_factor") or 1
+    local scale_factor     = G_reader_settings:readSetting("dogear_scale_factor") or 1
     local custom_icon_path = G_reader_settings:readSetting("dogear_custom_icon")
 
     -- Nothing to do if both settings are at their defaults.
@@ -246,49 +380,56 @@ function DogearManager:patchReaderDogear()
 
     local ReaderDogear = require("apps/reader/modules/readerdogear")
 
-    -- Patch init() to multiply the min/max sizes by the scale factor.
-    if scale_factor ~= 1 then
-        local orig_init = ReaderDogear.init
-        ReaderDogear.init = function(rd_self)
-            orig_init(rd_self)
-            rd_self.dogear_min_size = math.ceil(rd_self.dogear_min_size * scale_factor)
-            rd_self.dogear_max_size = math.ceil(rd_self.dogear_max_size * scale_factor)
-            -- Force setupDogear to rebuild with the new sizes.
-            rd_self.dogear_size = nil
-            rd_self:setupDogear()
-        end
-    end
-
     -- Patch setupDogear() to swap the built-in IconWidget for our custom image.
+    -- This runs for every future setupDogear call (including the one triggered
+    -- by the patched init below).
     if custom_icon_path then
-        local ImageWidget = require("ui/widget/imagewidget")
         local orig_setupDogear = ReaderDogear.setupDogear
         ReaderDogear.setupDogear = function(rd_self, new_dogear_size)
             orig_setupDogear(rd_self, new_dogear_size)
-            -- Replace the freshly-created IconWidget with our custom file.
             if rd_self.icon and rd_self.vgroup then
                 rd_self.icon:free()
                 rd_self.icon = ImageWidget:new{
-                    file = custom_icon_path,
-                    width = rd_self.dogear_size,
+                    file   = custom_icon_path,
+                    width  = rd_self.dogear_size,
                     height = rd_self.dogear_size,
-                    alpha = true,
+                    alpha  = true,
                 }
                 rd_self.vgroup[2] = rd_self.icon
             end
         end
     end
 
-    -- Also apply to the already-initialised instance when the plugin loads
-    -- after ReaderDogear (which is the common case inside ReaderUI).
-    if self.ui.dogear then
-        if scale_factor ~= 1 then
-            self.ui.dogear.dogear_min_size = math.ceil(self.ui.dogear.dogear_min_size * scale_factor)
-            self.ui.dogear.dogear_max_size = math.ceil(self.ui.dogear.dogear_max_size * scale_factor)
+    -- Patch init() so that any future ReaderDogear instance is scaled correctly.
+    -- FIX: after orig_init runs, dogear_size holds the unscaled computed size.
+    -- We multiply that directly and pass it to setupDogear() so the clamped
+    -- min/max calculation in setupDogear cannot suppress the scale.
+    if scale_factor ~= 1 then
+        local orig_init = ReaderDogear.init
+        ReaderDogear.init = function(rd_self)
+            orig_init(rd_self)
+            local base_size = rd_self.dogear_size
+            if base_size then
+                -- Pass the scaled size explicitly; setupDogear will use it
+                -- directly instead of re-deriving from screen / min-max.
+                rd_self:setupDogear(math.ceil(base_size * scale_factor))
+            end
         end
-        -- Force a full rebuild so both scale and icon patches take effect.
-        self.ui.dogear.dogear_size = nil
-        self.ui.dogear:setupDogear()
+    end
+
+    -- Apply to the already-initialised instance (common case: plugin loads
+    -- alongside an open document after ReaderDogear is already ready).
+    if self.ui.dogear then
+        local base_size = self.ui.dogear.dogear_size
+        if base_size and scale_factor ~= 1 then
+            -- Scale the existing instance's dogear_size directly.
+            self.ui.dogear:setupDogear(math.ceil(base_size * scale_factor))
+        elseif custom_icon_path then
+            -- No scale change but custom icon: force a rebuild so the
+            -- patched setupDogear above swaps the icon.
+            self.ui.dogear.dogear_size = nil
+            self.ui.dogear:setupDogear()
+        end
         self.ui.dogear:resetLayout()
     end
 end
@@ -314,7 +455,7 @@ function DogearManager:addToMainMenu(menu_items)
                 text = _("Adjust Bookmark Size"),
                 keep_menu_open = false,
                 callback = function()
-                    self:showSizeDialog()
+                    self:showSizeSlider()
                 end,
             },
             {
@@ -325,7 +466,7 @@ function DogearManager:addToMainMenu(menu_items)
                     G_reader_settings:delSetting("dogear_custom_icon_name")
                     G_reader_settings:delSetting("dogear_scale_factor")
                     UIManager:show(InfoMessage:new{
-                        text = _("Dogear reset to original defaults."),
+                        text    = _("Dogear reset to original defaults."),
                         timeout = 2,
                     })
                     UIManager:scheduleIn(2.5, function()


### PR DESCRIPTION
- Fix patchReaderDogear: scale dogear_size directly instead of scaling
  dogear_min_size/dogear_max_size, which were being overridden by the
  screen-dimension clamp inside setupDogear and had no real effect
- Fix existing-instance patch to use same direct-size approach
- Replace InputDialog (numeric text field) with a custom slider dialog:
  - Five buttons: -0.5, -, [value], +, +0.5 in a horizontal row
  - Range 0.5x – 4.0x, step 0.1
  - Live icon preview: rebuilds the dialog on each tap so the preview
    icon (custom image or black square stand-in) immediately reflects
    the new scale
  - Fixed-height preview area prevents layout jumps between steps
  - Cancel / Reset / Apply action row at the bottom

https://claude.ai/code/session_01LxCmqcHmVwmdjoNo9ZozY6