### PR TITLE
fix: prevent modal freeze when rapidly scrolling icons

### DIFF
--- a/dogearmanager.koplugin/main.lua
+++ b/dogearmanager.koplugin/main.lua
@@ -259,8 +259,15 @@ function DogearManager:showSizeSlider(scale, margin_top, margin_right, icon_idx)
     -- top_widget is the root widget passed to UIManager:show / close.
     local top_widget
 
+    -- Guard against queuing multiple rebuilds from rapid button taps.
+    -- Without this, each tap schedules another showSizeSlider, stacking
+    -- modals until UIManager freezes.
+    local rebuild_pending = false
+
     -- Close and rebuild at new values (live-update pattern).
     local function rebuild(ns, nmt, nmr, ni)
+        if rebuild_pending then return end
+        rebuild_pending = true
         UIManager:close(top_widget)
         UIManager:scheduleIn(0, function()
             self:showSizeSlider(ns, nmt, nmr, ni)


### PR DESCRIPTION
Each button tap in the scale/margin modal called rebuild(), which
scheduled a new showSizeSlider() invocation via UIManager:scheduleIn(0).
Rapid taps queued multiple scheduled callbacks before any could fire,
stacking new modals on top of each other until UIManager froze.

Add a rebuild_pending guard so only one rebuild can be in flight at a
time — subsequent taps are ignored until the new modal opens.

https://claude.ai/code/session_012u8M73MWRKVsuuW4s2NY2t