### PR TITLE
Fix plugin crash in FileManager by deferring patchReaderDogear to onReaderReady

### DIFF
--- a/dogearmanager.koplugin/main.lua
+++ b/dogearmanager.koplugin/main.lua
@@ -663,6 +663,9 @@ end
 
 function DogearManager:init()
     self.ui.menu:registerToMainMenu(self)
+end
+
+function DogearManager:onReaderReady()
     self:patchReaderDogear()
 end
 


### PR DESCRIPTION
Move self:patchReaderDogear() out of init() and into a new onReaderReady()
handler. Since is_doc_only = false, init() runs in the FileManager context
where ReaderDogear and self.ui.dogear do not exist yet, causing failures.
onReaderReady fires only in the Reader context after all submodules are
fully initialized, making it the correct and safe time to monkey-patch.

https://claude.ai/code/session_01SpEDabFLQvJXQiy2ob7PKi