### PR TITLE
fix: persist dogear settings across restarts and surface patching errors

### DIFF
--- a/dogearmanager.koplugin/main.lua
+++ b/dogearmanager.koplugin/main.lua
@@ -98,6 +98,7 @@ function DogearManager:promptRestart()
         ok_text = _("Restart"),
         cancel_text = _("Cancel"),
         ok_callback = function()
+            G_reader_settings:flush()
             if Device:canRestart() then
                 UIManager:restartKOReader()
             else
@@ -589,7 +590,7 @@ function DogearManager:patchReaderDogear()
                 if sf ~= 1 then
                     if new_dogear_size then
                         new_dogear_size = math.ceil(new_dogear_size * sf)
-                    else
+                    elseif rd_self.dogear_max_size then
                         new_dogear_size = math.ceil(rd_self.dogear_max_size * sf)
                     end
                 end
@@ -627,12 +628,12 @@ function DogearManager:patchReaderDogear()
             end
         end
 
-        self:applyDogearToLive()
     end)
 
     if not ok then
         logger.err("DogearManager: patchReaderDogear failed:", err)
     end
+    self:applyDogearToLive()
 end
 
 function DogearManager:init()


### PR DESCRIPTION
Three bugs prevented settings from surviving a KOReader restart:

1. G_reader_settings:flush() was never called before restarting, so
   saveSetting() values lived only in memory and were lost on restart.
   Now flush() is called in promptRestart() before UIManager:restartKOReader().

2. applyDogearToLive() was inside the pcall in patchReaderDogear(), so if
   anything threw during setup (e.g. a nil dogear_max_size), the live-apply
   was silently skipped. Moved it outside the pcall so it always runs and
   errors are visible.

3. Added a nil guard for rd_self.dogear_max_size in the setupDogear patch
   so math.ceil(nil * sf) can no longer throw when the field is unset.

https://claude.ai/code/session_015D16C1pqvYK5Tje5m1s5WZ