### PR TITLE
Fix Apply button not closing modal until page flip

### DIFF
--- a/dogearmanager.koplugin/main.lua
+++ b/dogearmanager.koplugin/main.lua
@@ -470,7 +470,9 @@ function DogearManager:showSizeSlider(scale, mt_steps, mr_steps, icon_idx, desig
                 -- Settings already applied live; just commit and close
                 self._slider_originals = nil
                 UIManager:close(top_widget)
-                UIManager:show(InfoMessage:new{ text = _("Bookmark updated."), timeout = 2 })
+                UIManager:scheduleIn(0, function()
+                    UIManager:show(InfoMessage:new{ text = _("Bookmark updated."), timeout = 2 })
+                end)
             end,
         },
     }


### PR DESCRIPTION
UIManager:show(InfoMessage) was called immediately after UIManager:close(top_widget),
causing the InfoMessage to render before the modal close was processed. When the
InfoMessage timed out, it only repainted its own area, leaving the modal visually
stuck. Schedule the InfoMessage with scheduleIn(0) so it fires after the close
is fully processed — same pattern used in the rebuild function.

https://claude.ai/code/session_01LsksXS2iFsHshR5fig2j6S